### PR TITLE
Fixed axiosConfig baseURL

### DIFF
--- a/src/api/axiosConfig.js
+++ b/src/api/axiosConfig.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
 export default axios.create({
-    baseURL:'https://notsteam.games', 
+    baseURL:'https://api.notsteam.games', 
     headers: {"ngrok-skip-browser-warning": "true"}
 })


### PR DESCRIPTION
Fixed axiosConfig base URL. Was 'https://notsteam.games', is now 'https://api.notsteam.games'